### PR TITLE
[PLAT-856] add docs on vscode settings & extensions

### DIFF
--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -1,0 +1,41 @@
+# Editor settings!
+
+Most of us are already using VSCode, so these docs mostly go over configuring some good-to-have editor settings for that. If you use something else, being the 1337H4xX0r you are, we leave it as an excise for the reader to figure out how to get the following functionality in your editor. If it feels like something someone else would benefit from knowing, document it here <3
+
+At a bare minimum, you should try to enable formatting on save & setup plugins/extensions for ESLint & Prettier.
+
+## Recommended VSCode Extensions
+The fact that this readme is in a file named `.vscode` is a hack. Clone this repo and open it in vscode, it will recommend a list of extensions for you to use. Don't feel obligated to use all or any of them. Have something others should know about? Add it to the `extensions.json`.
+
+They all have comments in the [extensions file](extensions.json), so check that to know if you actually want a thing.
+
+## Recommended VSCode Settings
+Settings in this section are as JSON set in VSCode's `settings.json`.
+
+Open your editor's settings JSON by opening the command pallette (Cmd+Shift+P) and running "Preferences: Open Settings (JSON)".
+
+Note that many of the formatting-specific options should be getting enforced by automated linters & formatters.
+
+There are many great settings in modern editors. These are just a few that affect the content of files. Feel free to add more. Do what you want.
+
+```jsonc
+{
+  // runs your default formatter on save!
+  "editor.formatOnSave": true,
+
+  // whitespace things
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "files.eol": "\n",
+
+  // useful for preventing prettier from messing with files not controlled by prettier
+  "prettier.requireConfig": true
+}
+```
+
+## A note about formatting from the editor
+Some useful commands you should know exist in the Command Palette (Cmd+Shift+P):
+* Format document (Shift+Cmd+F)
+* Format document with... - allows you to pick a specific formatter if you have multiple. Also, is how you can easily set defualt formatter.
+* Save without formatting (Cmd+K S) - sometimes you don't want the editor to take control

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,47 @@
+{
+  "recommendations": [
+    //////////
+    // Language/Framework support
+    //////////
+    // JS/TS
+    "ms-vscode.vscode-typescript-next",
+    // Golang
+    "golang.go",
+    // Python
+    "ms-python.python",
+    // Terraform
+    "hashicorp.terraform",
+    // Swagger/OpenAPI
+    "arjun.swagger-viewer",
+    // SQL formatting
+    "adpyke.vscode-sql-formatter",
+    // K8s
+    "ms-kubernetes-tools.vscode-kubernetes-tools",
+
+    //////////
+    // Essential JS/Vue linting/formatting business
+    //////////
+    // Eslint in your editor! Squiggly lines teach you to code better.
+    "dbaeumer.vscode-eslint",
+    // Prettier formatter (great for format-on-save)
+    "esbenp.prettier-vscode",
+    // Vue tooling
+    "octref.vetur",
+
+
+    //////////
+    // Random fun formatting/highlighting
+    //////////
+    // Screenshare/Remote collaboration!
+    "ms-vsliveshare.vsliveshare",
+
+    // rainbow brackets highlights each level of nested brackets a different color which makes it
+    // easy to know where you are in nested brackets/parens/braces
+    "2gua.rainbow-brackets",
+
+    // better comments colors the text of comments that are prefixed with special characters
+    // ! like this!
+    // ? or this?
+    "aaron-bond.better-comments"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,5 @@ First, make sure you have an npm account with the necessary permissions to publi
 
 To use your new version in a project simply run `npm i <package-name>@latest`.
 
----
-
-TODO docs
-* VSCode settings & recommended extensions
+# VSCode Settings
+This repo also contains info about preferred editor settings & some recommended extensions if you use VSCode. Find details about that [here](./.vscode#readme).


### PR DESCRIPTION
Opening a PR so that all y'all get pinged with these docs.  PSA: this repo exists. Clone it, open it in VSCode, & it will recommend extensions for you.

Also contains editor settings you should consider adding so we stop stepping on each other's whitespace formatting toes 😄 

Will find the place(s) this kinda documentation lives/should live and will link to this from there.